### PR TITLE
Add Ruby 3.4 to CI pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.3']
+        ruby-version: ['3.2', '3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         ruby:
           - '3.3.1'
+          - '3.4.0-preview1'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add Ruby 3.4 to the main GitHub Actions matrix
- ensure the existing CI job also runs against Ruby 3.4

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24ee1b6508330b0eadef767cc2135